### PR TITLE
fix: Expand mask in forward attention

### DIFF
--- a/crates/burn-lm-llama/src/nn/attention/mha.rs
+++ b/crates/burn-lm-llama/src/nn/attention/mha.rs
@@ -162,7 +162,10 @@ impl<B: Backend> MultiHeadAttention<B> {
             .div_scalar((self.head_dim as f32).sqrt());
 
         if let Some(mask) = mask {
-            scores = scores.mask_fill(mask, f32::NEG_INFINITY);
+            let expanded_mask = mask
+                .clone()
+                .expand([batch_size, self.n_heads, seq_len, seq_len]);
+            scores = scores.mask_fill(expanded_mask, f32::NEG_INFINITY);
         }
 
         let scores = softmax(scores, 3);


### PR DESCRIPTION
Was breaking here with llama32 

```
called `Result::unwrap()` on an `Err` value: shape mismatch in where_cond, lhs: [1, 1, 13, 13], rhs: [1, 32, 13, 13]
```