### PR TITLE
Force pending deallocations w/ unload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,9 +87,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.19"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
+checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -117,22 +117,22 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.9"
+version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -220,6 +220,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "atomic_float"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -285,7 +291,7 @@ dependencies = [
  "sha1",
  "sync_wrapper",
  "tokio",
- "tokio-tungstenite 0.26.2",
+ "tokio-tungstenite",
  "tower",
  "tower-layer",
  "tower-service",
@@ -380,6 +386,26 @@ checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
 dependencies = [
  "serde",
  "unty",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.71.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
+dependencies = [
+ "bitflags 2.9.1",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.11.0",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 2.1.1",
+ "shlex",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -502,10 +528,11 @@ checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 [[package]]
 name = "burn"
 version = "0.19.0"
-source = "git+https://github.com/tracel-ai/burn?rev=38874ebe6672877b9bacedcf9083dfc8a5a34eca#38874ebe6672877b9bacedcf9083dfc8a5a34eca"
+source = "git+https://github.com/tracel-ai/burn?rev=2b671dbcd9b483aea36dc1a2acf213163269dd01#2b671dbcd9b483aea36dc1a2acf213163269dd01"
 dependencies = [
  "burn-autodiff",
  "burn-candle",
+ "burn-collective",
  "burn-core",
  "burn-cuda",
  "burn-ir",
@@ -521,7 +548,7 @@ dependencies = [
 [[package]]
 name = "burn-autodiff"
 version = "0.19.0"
-source = "git+https://github.com/tracel-ai/burn?rev=38874ebe6672877b9bacedcf9083dfc8a5a34eca#38874ebe6672877b9bacedcf9083dfc8a5a34eca"
+source = "git+https://github.com/tracel-ai/burn?rev=2b671dbcd9b483aea36dc1a2acf213163269dd01#2b671dbcd9b483aea36dc1a2acf213163269dd01"
 dependencies = [
  "burn-common",
  "burn-tensor",
@@ -536,7 +563,7 @@ dependencies = [
 [[package]]
 name = "burn-candle"
 version = "0.19.0"
-source = "git+https://github.com/tracel-ai/burn?rev=38874ebe6672877b9bacedcf9083dfc8a5a34eca#38874ebe6672877b9bacedcf9083dfc8a5a34eca"
+source = "git+https://github.com/tracel-ai/burn?rev=2b671dbcd9b483aea36dc1a2acf213163269dd01#2b671dbcd9b483aea36dc1a2acf213163269dd01"
 dependencies = [
  "burn-common",
  "burn-tensor",
@@ -546,9 +573,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "burn-collective"
+version = "0.19.0"
+source = "git+https://github.com/tracel-ai/burn?rev=2b671dbcd9b483aea36dc1a2acf213163269dd01#2b671dbcd9b483aea36dc1a2acf213163269dd01"
+dependencies = [
+ "burn-common",
+ "burn-communication",
+ "burn-tensor",
+ "bytes",
+ "futures",
+ "log",
+ "rmp-serde",
+ "serde",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "burn-common"
 version = "0.19.0"
-source = "git+https://github.com/tracel-ai/burn?rev=38874ebe6672877b9bacedcf9083dfc8a5a34eca#38874ebe6672877b9bacedcf9083dfc8a5a34eca"
+source = "git+https://github.com/tracel-ai/burn?rev=2b671dbcd9b483aea36dc1a2acf213163269dd01#2b671dbcd9b483aea36dc1a2acf213163269dd01"
 dependencies = [
  "cubecl-common",
  "indicatif 0.18.0",
@@ -559,9 +603,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "burn-communication"
+version = "0.19.0"
+source = "git+https://github.com/tracel-ai/burn?rev=2b671dbcd9b483aea36dc1a2acf213163269dd01#2b671dbcd9b483aea36dc1a2acf213163269dd01"
+dependencies = [
+ "axum",
+ "burn-common",
+ "burn-tensor",
+ "bytes",
+ "derive-new",
+ "futures",
+ "futures-util",
+ "log",
+ "rmp-serde",
+ "serde",
+ "serde_bytes",
+ "tokio",
+ "tokio-tungstenite",
+ "tokio-util",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "burn-core"
 version = "0.19.0"
-source = "git+https://github.com/tracel-ai/burn?rev=38874ebe6672877b9bacedcf9083dfc8a5a34eca#38874ebe6672877b9bacedcf9083dfc8a5a34eca"
+source = "git+https://github.com/tracel-ai/burn?rev=2b671dbcd9b483aea36dc1a2acf213163269dd01#2b671dbcd9b483aea36dc1a2acf213163269dd01"
 dependencies = [
  "ahash",
  "bincode",
@@ -588,7 +655,7 @@ dependencies = [
 [[package]]
 name = "burn-cubecl"
 version = "0.19.0"
-source = "git+https://github.com/tracel-ai/burn?rev=38874ebe6672877b9bacedcf9083dfc8a5a34eca#38874ebe6672877b9bacedcf9083dfc8a5a34eca"
+source = "git+https://github.com/tracel-ai/burn?rev=2b671dbcd9b483aea36dc1a2acf213163269dd01#2b671dbcd9b483aea36dc1a2acf213163269dd01"
 dependencies = [
  "burn-common",
  "burn-cubecl-fusion",
@@ -612,7 +679,7 @@ dependencies = [
 [[package]]
 name = "burn-cubecl-fusion"
 version = "0.19.0"
-source = "git+https://github.com/tracel-ai/burn?rev=38874ebe6672877b9bacedcf9083dfc8a5a34eca#38874ebe6672877b9bacedcf9083dfc8a5a34eca"
+source = "git+https://github.com/tracel-ai/burn?rev=2b671dbcd9b483aea36dc1a2acf213163269dd01#2b671dbcd9b483aea36dc1a2acf213163269dd01"
 dependencies = [
  "burn-common",
  "burn-fusion",
@@ -627,7 +694,7 @@ dependencies = [
 [[package]]
 name = "burn-cuda"
 version = "0.19.0"
-source = "git+https://github.com/tracel-ai/burn?rev=38874ebe6672877b9bacedcf9083dfc8a5a34eca#38874ebe6672877b9bacedcf9083dfc8a5a34eca"
+source = "git+https://github.com/tracel-ai/burn?rev=2b671dbcd9b483aea36dc1a2acf213163269dd01#2b671dbcd9b483aea36dc1a2acf213163269dd01"
 dependencies = [
  "burn-cubecl",
  "burn-fusion",
@@ -642,7 +709,7 @@ dependencies = [
 [[package]]
 name = "burn-dataset"
 version = "0.19.0"
-source = "git+https://github.com/tracel-ai/burn?rev=38874ebe6672877b9bacedcf9083dfc8a5a34eca#38874ebe6672877b9bacedcf9083dfc8a5a34eca"
+source = "git+https://github.com/tracel-ai/burn?rev=2b671dbcd9b483aea36dc1a2acf213163269dd01#2b671dbcd9b483aea36dc1a2acf213163269dd01"
 dependencies = [
  "csv",
  "derive-new",
@@ -666,7 +733,7 @@ dependencies = [
 [[package]]
 name = "burn-derive"
 version = "0.19.0"
-source = "git+https://github.com/tracel-ai/burn?rev=38874ebe6672877b9bacedcf9083dfc8a5a34eca#38874ebe6672877b9bacedcf9083dfc8a5a34eca"
+source = "git+https://github.com/tracel-ai/burn?rev=2b671dbcd9b483aea36dc1a2acf213163269dd01#2b671dbcd9b483aea36dc1a2acf213163269dd01"
 dependencies = [
  "derive-new",
  "proc-macro2",
@@ -677,7 +744,7 @@ dependencies = [
 [[package]]
 name = "burn-fusion"
 version = "0.19.0"
-source = "git+https://github.com/tracel-ai/burn?rev=38874ebe6672877b9bacedcf9083dfc8a5a34eca#38874ebe6672877b9bacedcf9083dfc8a5a34eca"
+source = "git+https://github.com/tracel-ai/burn?rev=2b671dbcd9b483aea36dc1a2acf213163269dd01#2b671dbcd9b483aea36dc1a2acf213163269dd01"
 dependencies = [
  "burn-common",
  "burn-ir",
@@ -693,7 +760,7 @@ dependencies = [
 [[package]]
 name = "burn-import"
 version = "0.19.0"
-source = "git+https://github.com/tracel-ai/burn?rev=38874ebe6672877b9bacedcf9083dfc8a5a34eca#38874ebe6672877b9bacedcf9083dfc8a5a34eca"
+source = "git+https://github.com/tracel-ai/burn?rev=2b671dbcd9b483aea36dc1a2acf213163269dd01#2b671dbcd9b483aea36dc1a2acf213163269dd01"
 dependencies = [
  "burn",
  "derive-new",
@@ -714,7 +781,7 @@ dependencies = [
 [[package]]
 name = "burn-ir"
 version = "0.19.0"
-source = "git+https://github.com/tracel-ai/burn?rev=38874ebe6672877b9bacedcf9083dfc8a5a34eca#38874ebe6672877b9bacedcf9083dfc8a5a34eca"
+source = "git+https://github.com/tracel-ai/burn?rev=2b671dbcd9b483aea36dc1a2acf213163269dd01#2b671dbcd9b483aea36dc1a2acf213163269dd01"
 dependencies = [
  "burn-tensor",
  "hashbrown 0.15.4",
@@ -848,7 +915,7 @@ dependencies = [
 [[package]]
 name = "burn-ndarray"
 version = "0.19.0"
-source = "git+https://github.com/tracel-ai/burn?rev=38874ebe6672877b9bacedcf9083dfc8a5a34eca#38874ebe6672877b9bacedcf9083dfc8a5a34eca"
+source = "git+https://github.com/tracel-ai/burn?rev=2b671dbcd9b483aea36dc1a2acf213163269dd01#2b671dbcd9b483aea36dc1a2acf213163269dd01"
 dependencies = [
  "atomic_float",
  "blas-src",
@@ -875,11 +942,12 @@ dependencies = [
 [[package]]
 name = "burn-remote"
 version = "0.19.0"
-source = "git+https://github.com/tracel-ai/burn?rev=38874ebe6672877b9bacedcf9083dfc8a5a34eca#38874ebe6672877b9bacedcf9083dfc8a5a34eca"
+source = "git+https://github.com/tracel-ai/burn?rev=2b671dbcd9b483aea36dc1a2acf213163269dd01#2b671dbcd9b483aea36dc1a2acf213163269dd01"
 dependencies = [
  "async-channel",
  "axum",
  "burn-common",
+ "burn-communication",
  "burn-ir",
  "burn-router",
  "burn-tensor",
@@ -891,7 +959,8 @@ dependencies = [
  "serde",
  "serde_bytes",
  "tokio",
- "tokio-tungstenite 0.27.0",
+ "tokio-tungstenite",
+ "tokio-util",
  "tracing-core",
  "tracing-subscriber",
 ]
@@ -899,7 +968,7 @@ dependencies = [
 [[package]]
 name = "burn-rocm"
 version = "0.19.0"
-source = "git+https://github.com/tracel-ai/burn?rev=38874ebe6672877b9bacedcf9083dfc8a5a34eca#38874ebe6672877b9bacedcf9083dfc8a5a34eca"
+source = "git+https://github.com/tracel-ai/burn?rev=2b671dbcd9b483aea36dc1a2acf213163269dd01#2b671dbcd9b483aea36dc1a2acf213163269dd01"
 dependencies = [
  "burn-cubecl",
  "burn-fusion",
@@ -914,7 +983,7 @@ dependencies = [
 [[package]]
 name = "burn-router"
 version = "0.19.0"
-source = "git+https://github.com/tracel-ai/burn?rev=38874ebe6672877b9bacedcf9083dfc8a5a34eca#38874ebe6672877b9bacedcf9083dfc8a5a34eca"
+source = "git+https://github.com/tracel-ai/burn?rev=2b671dbcd9b483aea36dc1a2acf213163269dd01#2b671dbcd9b483aea36dc1a2acf213163269dd01"
 dependencies = [
  "burn-common",
  "burn-ir",
@@ -927,7 +996,7 @@ dependencies = [
 [[package]]
 name = "burn-tch"
 version = "0.19.0"
-source = "git+https://github.com/tracel-ai/burn?rev=38874ebe6672877b9bacedcf9083dfc8a5a34eca#38874ebe6672877b9bacedcf9083dfc8a5a34eca"
+source = "git+https://github.com/tracel-ai/burn?rev=2b671dbcd9b483aea36dc1a2acf213163269dd01#2b671dbcd9b483aea36dc1a2acf213163269dd01"
 dependencies = [
  "burn-tensor",
  "cc",
@@ -941,7 +1010,7 @@ dependencies = [
 [[package]]
 name = "burn-tensor"
 version = "0.19.0"
-source = "git+https://github.com/tracel-ai/burn?rev=38874ebe6672877b9bacedcf9083dfc8a5a34eca#38874ebe6672877b9bacedcf9083dfc8a5a34eca"
+source = "git+https://github.com/tracel-ai/burn?rev=2b671dbcd9b483aea36dc1a2acf213163269dd01#2b671dbcd9b483aea36dc1a2acf213163269dd01"
 dependencies = [
  "burn-common",
  "bytemuck",
@@ -960,7 +1029,7 @@ dependencies = [
 [[package]]
 name = "burn-train"
 version = "0.19.0"
-source = "git+https://github.com/tracel-ai/burn?rev=38874ebe6672877b9bacedcf9083dfc8a5a34eca#38874ebe6672877b9bacedcf9083dfc8a5a34eca"
+source = "git+https://github.com/tracel-ai/burn?rev=2b671dbcd9b483aea36dc1a2acf213163269dd01#2b671dbcd9b483aea36dc1a2acf213163269dd01"
 dependencies = [
  "async-channel",
  "burn-core",
@@ -981,7 +1050,7 @@ dependencies = [
 [[package]]
 name = "burn-wgpu"
 version = "0.19.0"
-source = "git+https://github.com/tracel-ai/burn?rev=38874ebe6672877b9bacedcf9083dfc8a5a34eca#38874ebe6672877b9bacedcf9083dfc8a5a34eca"
+source = "git+https://github.com/tracel-ai/burn?rev=2b671dbcd9b483aea36dc1a2acf213163269dd01#2b671dbcd9b483aea36dc1a2acf213163269dd01"
 dependencies = [
  "burn-cubecl",
  "burn-fusion",
@@ -1140,6 +1209,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "caseless"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6fd507454086c8edfd769ca6ada439193cdb209c7681712ef6275cccbfe5d8"
+dependencies = [
+ "unicode-normalization",
+]
+
+[[package]]
 name = "cassowary"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1165,13 +1243,22 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.30"
+version = "1.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deec109607ca693028562ed836a5f1c4b8bd77755c4e132fc5ce11b0b6211ae7"
+checksum = "c3a42d84bb6b69d3a8b3eaacf0d88f179e1929695e1ad012b6cf64d9caaa5fd2"
 dependencies = [
  "jobserver",
  "libc",
  "shlex",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -1222,10 +1309,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap"
-version = "4.5.41"
+name = "clang-sys"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
+name = "clap"
+version = "4.5.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50fd97c9dc2399518aa331917ac6f274280ec5eb34e555dd291899745c48ec6f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1233,9 +1331,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.41"
+version = "4.5.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
+checksum = "c35b5830294e1fa0462034af85cc95225a4cb07092c088c55bda3147cfcd8f65"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1360,6 +1458,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "comrak"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fefab951771fc3beeed0773ce66a4f7b706273fc6c4c95b08dd1615744abcf5"
+dependencies = [
+ "caseless",
+ "entities",
+ "memchr",
+ "slug",
+ "typed-arena",
+ "unicode_categories",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1399,6 +1511,15 @@ name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+
+[[package]]
+name = "convert_case"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baaaa0ecca5b51987b9423ccdc971514dd8b0bb7b4060b983d3664dad3f1f89f"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "core-foundation"
@@ -1560,10 +1681,11 @@ dependencies = [
 [[package]]
 name = "cubecl"
 version = "0.7.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=f1b0080edc55c9a0dd02fad333f81a02a200beea#f1b0080edc55c9a0dd02fad333f81a02a200beea"
+source = "git+https://github.com/tracel-ai/cubecl?rev=e7ea768818651d6d0b3c687659940751868042b5#e7ea768818651d6d0b3c687659940751868042b5"
 dependencies = [
  "cubecl-convolution",
  "cubecl-core",
+ "cubecl-cpu",
  "cubecl-cuda",
  "cubecl-hip",
  "cubecl-matmul",
@@ -1578,7 +1700,7 @@ dependencies = [
 [[package]]
 name = "cubecl-common"
 version = "0.7.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=f1b0080edc55c9a0dd02fad333f81a02a200beea#f1b0080edc55c9a0dd02fad333f81a02a200beea"
+source = "git+https://github.com/tracel-ai/cubecl?rev=e7ea768818651d6d0b3c687659940751868042b5#e7ea768818651d6d0b3c687659940751868042b5"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -1605,7 +1727,7 @@ dependencies = [
 [[package]]
 name = "cubecl-convolution"
 version = "0.7.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=f1b0080edc55c9a0dd02fad333f81a02a200beea#f1b0080edc55c9a0dd02fad333f81a02a200beea"
+source = "git+https://github.com/tracel-ai/cubecl?rev=e7ea768818651d6d0b3c687659940751868042b5#e7ea768818651d6d0b3c687659940751868042b5"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1616,13 +1738,14 @@ dependencies = [
  "cubecl-runtime",
  "cubecl-std",
  "half",
+ "pretty_assertions",
  "serde",
 ]
 
 [[package]]
 name = "cubecl-core"
 version = "0.7.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=f1b0080edc55c9a0dd02fad333f81a02a200beea#f1b0080edc55c9a0dd02fad333f81a02a200beea"
+source = "git+https://github.com/tracel-ai/cubecl?rev=e7ea768818651d6d0b3c687659940751868042b5#e7ea768818651d6d0b3c687659940751868042b5"
 dependencies = [
  "bitflags 2.9.1",
  "bytemuck",
@@ -1645,7 +1768,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpp"
 version = "0.7.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=f1b0080edc55c9a0dd02fad333f81a02a200beea#f1b0080edc55c9a0dd02fad333f81a02a200beea"
+source = "git+https://github.com/tracel-ai/cubecl?rev=e7ea768818651d6d0b3c687659940751868042b5#e7ea768818651d6d0b3c687659940751868042b5"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1657,9 +1780,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "cubecl-cpu"
+version = "0.7.0"
+source = "git+https://github.com/tracel-ai/cubecl?rev=e7ea768818651d6d0b3c687659940751868042b5#e7ea768818651d6d0b3c687659940751868042b5"
+dependencies = [
+ "bytemuck",
+ "cubecl-common",
+ "cubecl-convolution",
+ "cubecl-core",
+ "cubecl-matmul",
+ "cubecl-opt",
+ "cubecl-reduce",
+ "cubecl-runtime",
+ "derive-new",
+ "half",
+ "libc",
+ "log",
+ "serde",
+ "sysinfo 0.36.1",
+ "tracel-llvm",
+]
+
+[[package]]
 name = "cubecl-cuda"
 version = "0.7.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=f1b0080edc55c9a0dd02fad333f81a02a200beea#f1b0080edc55c9a0dd02fad333f81a02a200beea"
+source = "git+https://github.com/tracel-ai/cubecl?rev=e7ea768818651d6d0b3c687659940751868042b5#e7ea768818651d6d0b3c687659940751868042b5"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1676,7 +1821,7 @@ dependencies = [
 [[package]]
 name = "cubecl-hip"
 version = "0.7.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=f1b0080edc55c9a0dd02fad333f81a02a200beea#f1b0080edc55c9a0dd02fad333f81a02a200beea"
+source = "git+https://github.com/tracel-ai/cubecl?rev=e7ea768818651d6d0b3c687659940751868042b5#e7ea768818651d6d0b3c687659940751868042b5"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1704,7 +1849,7 @@ dependencies = [
 [[package]]
 name = "cubecl-ir"
 version = "0.7.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=f1b0080edc55c9a0dd02fad333f81a02a200beea#f1b0080edc55c9a0dd02fad333f81a02a200beea"
+source = "git+https://github.com/tracel-ai/cubecl?rev=e7ea768818651d6d0b3c687659940751868042b5#e7ea768818651d6d0b3c687659940751868042b5"
 dependencies = [
  "cubecl-common",
  "cubecl-macros-internal",
@@ -1722,10 +1867,10 @@ dependencies = [
 [[package]]
 name = "cubecl-macros"
 version = "0.7.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=f1b0080edc55c9a0dd02fad333f81a02a200beea#f1b0080edc55c9a0dd02fad333f81a02a200beea"
+source = "git+https://github.com/tracel-ai/cubecl?rev=e7ea768818651d6d0b3c687659940751868042b5#e7ea768818651d6d0b3c687659940751868042b5"
 dependencies = [
  "cubecl-common",
- "darling 0.21.0",
+ "darling 0.21.1",
  "derive-new",
  "ident_case",
  "prettyplease",
@@ -1737,9 +1882,9 @@ dependencies = [
 [[package]]
 name = "cubecl-macros-internal"
 version = "0.7.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=f1b0080edc55c9a0dd02fad333f81a02a200beea#f1b0080edc55c9a0dd02fad333f81a02a200beea"
+source = "git+https://github.com/tracel-ai/cubecl?rev=e7ea768818651d6d0b3c687659940751868042b5#e7ea768818651d6d0b3c687659940751868042b5"
 dependencies = [
- "darling 0.21.0",
+ "darling 0.21.1",
  "proc-macro2",
  "quote",
  "syn 2.0.104",
@@ -1748,7 +1893,7 @@ dependencies = [
 [[package]]
 name = "cubecl-matmul"
 version = "0.7.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=f1b0080edc55c9a0dd02fad333f81a02a200beea#f1b0080edc55c9a0dd02fad333f81a02a200beea"
+source = "git+https://github.com/tracel-ai/cubecl?rev=e7ea768818651d6d0b3c687659940751868042b5#e7ea768818651d6d0b3c687659940751868042b5"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1758,13 +1903,14 @@ dependencies = [
  "cubecl-runtime",
  "cubecl-std",
  "half",
+ "pretty_assertions",
  "serde",
 ]
 
 [[package]]
 name = "cubecl-opt"
 version = "0.7.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=f1b0080edc55c9a0dd02fad333f81a02a200beea#f1b0080edc55c9a0dd02fad333f81a02a200beea"
+source = "git+https://github.com/tracel-ai/cubecl?rev=e7ea768818651d6d0b3c687659940751868042b5#e7ea768818651d6d0b3c687659940751868042b5"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -1781,7 +1927,7 @@ dependencies = [
 [[package]]
 name = "cubecl-random"
 version = "0.7.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=f1b0080edc55c9a0dd02fad333f81a02a200beea#f1b0080edc55c9a0dd02fad333f81a02a200beea"
+source = "git+https://github.com/tracel-ai/cubecl?rev=e7ea768818651d6d0b3c687659940751868042b5#e7ea768818651d6d0b3c687659940751868042b5"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -1796,20 +1942,22 @@ dependencies = [
 [[package]]
 name = "cubecl-reduce"
 version = "0.7.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=f1b0080edc55c9a0dd02fad333f81a02a200beea#f1b0080edc55c9a0dd02fad333f81a02a200beea"
+source = "git+https://github.com/tracel-ai/cubecl?rev=e7ea768818651d6d0b3c687659940751868042b5#e7ea768818651d6d0b3c687659940751868042b5"
 dependencies = [
  "cubecl-core",
  "cubecl-runtime",
  "cubecl-std",
  "half",
  "num-traits",
+ "pretty_assertions",
+ "rand 0.9.2",
  "serde",
 ]
 
 [[package]]
 name = "cubecl-runtime"
 version = "0.7.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=f1b0080edc55c9a0dd02fad333f81a02a200beea#f1b0080edc55c9a0dd02fad333f81a02a200beea"
+source = "git+https://github.com/tracel-ai/cubecl?rev=e7ea768818651d6d0b3c687659940751868042b5#e7ea768818651d6d0b3c687659940751868042b5"
 dependencies = [
  "async-channel",
  "bytemuck",
@@ -1826,7 +1974,7 @@ dependencies = [
  "serde",
  "serde_json",
  "spin",
- "toml 0.9.3",
+ "toml 0.9.5",
  "variadics_please",
  "wasm-bindgen-futures",
 ]
@@ -1834,7 +1982,7 @@ dependencies = [
 [[package]]
 name = "cubecl-spirv"
 version = "0.7.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=f1b0080edc55c9a0dd02fad333f81a02a200beea#f1b0080edc55c9a0dd02fad333f81a02a200beea"
+source = "git+https://github.com/tracel-ai/cubecl?rev=e7ea768818651d6d0b3c687659940751868042b5#e7ea768818651d6d0b3c687659940751868042b5"
 dependencies = [
  "bitflags 2.9.1",
  "cubecl-common",
@@ -1850,7 +1998,7 @@ dependencies = [
 [[package]]
 name = "cubecl-std"
 version = "0.7.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=f1b0080edc55c9a0dd02fad333f81a02a200beea#f1b0080edc55c9a0dd02fad333f81a02a200beea"
+source = "git+https://github.com/tracel-ai/cubecl?rev=e7ea768818651d6d0b3c687659940751868042b5#e7ea768818651d6d0b3c687659940751868042b5"
 dependencies = [
  "cubecl-core",
  "cubecl-runtime",
@@ -1861,7 +2009,7 @@ dependencies = [
 [[package]]
 name = "cubecl-wgpu"
 version = "0.7.0"
-source = "git+https://github.com/tracel-ai/cubecl?rev=f1b0080edc55c9a0dd02fad333f81a02a200beea#f1b0080edc55c9a0dd02fad333f81a02a200beea"
+source = "git+https://github.com/tracel-ai/cubecl?rev=e7ea768818651d6d0b3c687659940751868042b5#e7ea768818651d6d0b3c687659940751868042b5"
 dependencies = [
  "ash",
  "async-channel",
@@ -1903,12 +2051,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a79c4acb1fd5fa3d9304be4c76e031c54d2e92d172a393e24b19a14fe8532fe9"
+checksum = "d6b136475da5ef7b6ac596c0e956e37bad51b85b987ff3d5e230e964936736b2"
 dependencies = [
- "darling_core 0.21.0",
- "darling_macro 0.21.0",
+ "darling_core 0.21.1",
+ "darling_macro 0.21.1",
 ]
 
 [[package]]
@@ -1927,9 +2075,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74875de90daf30eb59609910b84d4d368103aaec4c924824c6799b28f77d6a1d"
+checksum = "b44ad32f92b75fb438b04b68547e521a548be8acc339a6dacc4a7121488f53e6"
 dependencies = [
  "fnv",
  "ident_case",
@@ -1952,11 +2100,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79f8e61677d5df9167cd85265f8e5f64b215cdea3fb55eebc3e622e44c7a146"
+checksum = "2b5be8a7a562d315a5b92a630c30cec6bcf663e6673f00fbb69cca66a6f521b9"
 dependencies = [
- "darling_core 0.21.0",
+ "darling_core 0.21.1",
  "quote",
  "syn 2.0.104",
 ]
@@ -2075,6 +2223,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "deunicode"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04"
+
+[[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2123,7 +2283,7 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users 0.5.0",
+ "redox_users 0.5.2",
  "windows-sys 0.60.2",
 ]
 
@@ -2257,6 +2417,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 
 [[package]]
+name = "entities"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5320ae4c3782150d900b79807611a59a99fc9a1d61d686faafc24b93fc8d7ca"
+
+[[package]]
 name = "enum-as-inner"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2347,9 +2513,9 @@ checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
 
 [[package]]
 name = "event-listener"
-version = "5.4.0"
+version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
 dependencies = [
  "concurrent-queue",
  "parking",
@@ -2528,6 +2694,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2544,6 +2725,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-io"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2551,9 +2743,9 @@ checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-lite"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5edaec856126859abb19ed65f39e90fea3a9574b9707f13539acf4abf7eb532"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
 dependencies = [
  "fastrand",
  "futures-core",
@@ -2597,6 +2789,7 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -2935,9 +3128,9 @@ dependencies = [
 
 [[package]]
 name = "gix-path"
-version = "0.10.19"
+version = "0.10.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6279d323d925ad4790602105ae27df4b915e7a7d81e4cdba2603121c03ad111"
+checksum = "06d37034a4c67bbdda76f7bcd037b2f7bc0fba0c09a6662b19697a5716e7b2fd"
 dependencies = [
  "bstr",
  "gix-trace",
@@ -3076,6 +3269,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
 dependencies = [
  "bitflags 2.9.1",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -3232,6 +3444,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -3258,6 +3471,22 @@ dependencies = [
  "tokio-rustls",
  "tower-service",
  "webpki-roots 1.0.2",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
 ]
 
 [[package]]
@@ -3723,6 +3952,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "liblzma"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0791ab7e08ccc8e0ce893f6906eb2703ed8739d8e89b57c0714e71bad09024c8"
+dependencies = [
+ "liblzma-sys",
+ "num_cpus",
+]
+
+[[package]]
+name = "liblzma-sys"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01b9596486f6d60c3bbe644c0e1be1aa6ccc472ad630fe8927b456973d7cb736"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3730,9 +3980,9 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libredox"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "360e552c93fa0e8152ab463bc4c4837fce76a225df11dfaeea66c313de5e61f7"
+checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
 dependencies = [
  "bitflags 2.9.1",
  "libc",
@@ -3782,6 +4032,20 @@ name = "litrs"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5e54036fe321fd421e10d732f155734c4e4afd610dd556d9a82833ab3ee0bed"
+
+[[package]]
+name = "llvm-bundler-rs"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08866ec89bd1a5dc12a394b90b6cdc711e4896dfdc9ef45bd1ffb918b01b12bb"
+dependencies = [
+ "bytes",
+ "dirs 6.0.0",
+ "liblzma",
+ "regex",
+ "reqwest",
+ "tar",
+]
 
 [[package]]
 name = "lock_api"
@@ -3926,6 +4190,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae960838283323069879657ca3de837e9f7bbb4c7bf6ea7f1b290d5e9476d2e0"
 
 [[package]]
+name = "melior"
+version = "0.24.0"
+source = "git+https://github.com/marcantoinem/melior?rev=c51378d9ff5ddee5396d1b91e6b2e3b10b99665c#c51378d9ff5ddee5396d1b91e6b2e3b10b99665c"
+dependencies = [
+ "melior-macro",
+ "mlir-sys",
+]
+
+[[package]]
+name = "melior-macro"
+version = "0.17.0"
+source = "git+https://github.com/marcantoinem/melior?rev=c51378d9ff5ddee5396d1b91e6b2e3b10b99665c#c51378d9ff5ddee5396d1b91e6b2e3b10b99665c"
+dependencies = [
+ "comrak",
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 2.0.104",
+ "tblgen",
+ "unindent",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4028,6 +4316,15 @@ dependencies = [
  "log",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "mlir-sys"
+version = "0.5.0"
+source = "git+https://github.com/marcantoinem/mlir-sys?branch=bundled#38a13a02d714ade61ebe5c6f7e0b605afc417f35"
+dependencies = [
+ "bindgen",
+ "llvm-bundler-rs",
 ]
 
 [[package]]
@@ -4562,7 +4859,7 @@ dependencies = [
 [[package]]
 name = "onnx-ir"
 version = "0.19.0"
-source = "git+https://github.com/tracel-ai/burn?rev=38874ebe6672877b9bacedcf9083dfc8a5a34eca#38874ebe6672877b9bacedcf9083dfc8a5a34eca"
+source = "git+https://github.com/tracel-ai/burn?rev=2b671dbcd9b483aea36dc1a2acf213163269dd01#2b671dbcd9b483aea36dc1a2acf213163269dd01"
 dependencies = [
  "bytemuck",
  "half",
@@ -4895,6 +5192,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
 
 [[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5036,9 +5343,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
-version = "0.38.0"
+version = "0.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8927b0664f5c5a98265138b7e3f90aa19a6b21353182469ace36d4ac527b7b1b"
+checksum = "9845d9dccf565065824e69f9f235fafba1587031eda353c1f1561cd6a6be78f4"
 dependencies = [
  "memchr",
 ]
@@ -5381,9 +5688,9 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
-version = "0.5.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.16",
  "libredox",
@@ -5457,14 +5764,17 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -5475,6 +5785,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "tower",
  "tower-http",
@@ -5938,9 +6249,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.141"
+version = "1.0.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
+checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
 dependencies = [
  "itoa",
  "memchr",
@@ -6058,9 +6369,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.5"
+version = "1.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
+checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
 dependencies = [
  "libc",
 ]
@@ -6099,6 +6410,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbff4acf519f630b3a3ddcfaea6c06b42174d9a44bc70c620e9ed1649d58b82a"
 dependencies = [
  "version_check",
+]
+
+[[package]]
+name = "slug"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "882a80f72ee45de3cc9a5afeb2da0331d58df69e4e7d8eeb5d3c7784ae67e724"
+dependencies = [
+ "deunicode",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -6411,6 +6732,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
+name = "tblgen"
+version = "0.6.0"
+source = "git+https://github.com/marcantoinem/tblgen-rs?branch=bundled#00daea1550e6ee19c4718499bc4cdd1378f7f667"
+dependencies = [
+ "bindgen",
+ "cc",
+ "llvm-bundler-rs",
+ "paste",
+ "thiserror 2.0.12",
+]
+
+[[package]]
 name = "tch"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6635,9 +6968,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.47.0"
+version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43864ed400b6043a4757a25c7a64a8efde741aed79a056a2fb348a406701bb35"
+checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
 dependencies = [
  "backtrace",
  "bytes",
@@ -6662,6 +6995,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.104",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -6694,26 +7037,14 @@ dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tungstenite 0.26.2",
-]
-
-[[package]]
-name = "tokio-tungstenite"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "489a59b6730eda1b0171fcfda8b121f4bee2b35cba8645ca35c5f7ba3eb736c1"
-dependencies = [
- "futures-util",
- "log",
- "tokio",
- "tungstenite 0.27.0",
+ "tungstenite",
 ]
 
 [[package]]
 name = "tokio-util"
-version = "0.7.15"
+version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
+checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
 dependencies = [
  "bytes",
  "futures-core",
@@ -6736,9 +7067,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.3"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e06723639aaded957e5a80be250c1f82f274b9d23ebb4d94163668470623461c"
+checksum = "75129e1dc5000bfbaa9fee9d1b21f974f9fbad9daec557a521ee6e080825f6e8"
 dependencies = [
  "indexmap",
  "serde",
@@ -6783,9 +7114,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97200572db069e74c512a14117b296ba0a80a30123fbbb5aa1f4a348f639ca30"
+checksum = "b551886f449aa90d4fe2bdaa9f4a2577ad2dde302c61ecf262d80b116db95c10"
 dependencies = [
  "winnow",
 ]
@@ -6873,6 +7204,14 @@ name = "tower-service"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracel-llvm"
+version = "0.1.0"
+source = "git+https://github.com/tracel-ai/tracel-llvm?rev=a5800d4c2886949ad38332e0f14f004df8f9f645#a5800d4c2886949ad38332e0f14f004df8f9f645"
+dependencies = [
+ "melior",
+]
 
 [[package]]
 name = "tracel-xtask"
@@ -7004,23 +7343,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tungstenite"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadc29d668c91fcc564941132e17b28a7ceb2f3ebf0b9dae3e03fd7a6748eb0d"
-dependencies = [
- "bytes",
- "data-encoding",
- "http",
- "httparse",
- "log",
- "rand 0.9.2",
- "sha1",
- "thiserror 2.0.12",
- "utf-8",
-]
-
-[[package]]
 name = "type-map"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7028,6 +7350,12 @@ checksum = "cb30dbbd9036155e74adad6812e9898d03ec374946234fbcebd5dfc7b9187b90"
 dependencies = [
  "rustc-hash 2.1.1",
 ]
+
+[[package]]
+name = "typed-arena"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
 name = "typenum"
@@ -7153,6 +7481,12 @@ name = "unicode_categories"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
+
+[[package]]
+name = "unindent"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "unit-prefix"
@@ -8487,9 +8821,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.2"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
+checksum = "e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b"
 dependencies = [
  "yoke 0.8.0",
  "zerofrom",
@@ -8620,9 +8954,9 @@ dependencies = [
 
 [[package]]
 name = "zune-jpeg"
-version = "0.4.19"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9e525af0a6a658e031e95f14b7f889976b74a11ba0eca5a5fc9ac8a1c43a6a"
+checksum = "fc1f7e205ce79eb2da3cd71c5f55f3589785cb7c79f6a03d1c8d1491bda5d089"
 dependencies = [
  "zune-core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,11 @@ readme = "README.md"
 # For dev
 burn = { git = "https://github.com/tracel-ai/burn", features = [
     "std",
-], default-features = false, rev = "38874ebe6672877b9bacedcf9083dfc8a5a34eca" }
+], default-features = false, rev = "2b671dbcd9b483aea36dc1a2acf213163269dd01" }
 burn-common = { git = "https://github.com/tracel-ai/burn", features = [
     "std",
-], default-features = false, rev = "38874ebe6672877b9bacedcf9083dfc8a5a34eca" }
-burn-import = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "38874ebe6672877b9bacedcf9083dfc8a5a34eca" }
+], default-features = false, rev = "2b671dbcd9b483aea36dc1a2acf213163269dd01" }
+burn-import = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "2b671dbcd9b483aea36dc1a2acf213163269dd01" }
 
 # For dev we use the local version of burn
 # burn = { path = "../burn/crates/burn", features = [

--- a/crates/burn-lm-cli/src/commands/run.rs
+++ b/crates/burn-lm-cli/src/commands/run.rs
@@ -89,6 +89,7 @@ fn run(plugin_name: &str, run_args: &clap::ArgMatches) -> super::HandleCommandRe
             if !run_args.get_flag("no-stats") {
                 crate::utils::display_stats(&answer);
             }
+            let _ = plugin.unload();
             Ok(None)
         }
         Err(err) => anyhow::bail!("An error occurred: {err}"),

--- a/crates/burn-lm-inference/src/client.rs
+++ b/crates/burn-lm-inference/src/client.rs
@@ -106,10 +106,12 @@ where
         let result = self.channel.unload();
 
         #[cfg(not(feature = "legacy-v018"))]
-        let device = &crate::INFERENCE_DEVICE;
-
-        #[cfg(not(feature = "legacy-v018"))]
-        <crate::InferenceBackend as Backend>::memory_cleanup(device);
+        {
+            let device = &crate::INFERENCE_DEVICE;
+            <crate::InferenceBackend as Backend>::memory_cleanup(device);
+            // Force pending deallocations to complete
+            <crate::InferenceBackend as Backend>::sync(device);
+        }
 
         result
     }


### PR DESCRIPTION
- Update burn rev for the cuda dealloc fix (https://github.com/tracel-ai/burn/pull/3487)
- Unload plugin after `run` execution
- Call `B::sync(&device)` on `plugin.unload()` to force pending deallocations