### PR TITLE
Add streaming decoder for buffered incremental decoding (fixes TinyLlama)

### DIFF
--- a/crates/burn-lm-llama/src/generation/mod.rs
+++ b/crates/burn-lm-llama/src/generation/mod.rs
@@ -1,7 +1,9 @@
 mod context;
 mod generate;
 mod sampling;
+mod streaming;
 
 pub use context::*;
 pub use generate::*;
 pub use sampling::*;
+pub use streaming::*;

--- a/crates/burn-lm-llama/src/generation/streaming.rs
+++ b/crates/burn-lm-llama/src/generation/streaming.rs
@@ -1,0 +1,58 @@
+use crate::tokenizer::Tokenizer;
+
+/// A streaming decoder wrapper for tokenizers that require
+/// buffering to correctly decode tokens incrementally.
+///
+/// This is useful for tokenizers like SentencePiece that rely on
+/// decoding context (e.g., byte-fallback fusion, leading spaces)
+/// and cannot decode tokens one-by-one correctly.
+#[derive(Debug, Clone)]
+pub struct StreamingDecoder<T: Tokenizer> {
+    tokenizer: T,
+    buffer: Vec<u32>,
+    context_size: usize,
+    context_overlap: usize,
+    emitted_tokens: usize,
+}
+
+impl<T: Tokenizer> StreamingDecoder<T> {
+    pub fn new(tokenizer: T) -> Self {
+        let context_size = tokenizer.streaming_context_size();
+        Self {
+            tokenizer,
+            buffer: Vec::with_capacity(context_size),
+            context_size,
+            context_overlap: 2,
+            emitted_tokens: 0,
+        }
+    }
+
+    /// Feed new tokens incrementally, decode buffered tokens, return only the newly decoded text slice.
+    pub fn push_tokens(&mut self, new_tokens: &[u32]) -> Option<String> {
+        if self.context_size == 0 {
+            return Some(self.tokenizer.decode(new_tokens));
+        }
+
+        self.buffer.extend_from_slice(new_tokens);
+
+        if self.buffer.len() - self.emitted_tokens < self.context_size {
+            return None;
+        }
+
+        let overlap_start = self.emitted_tokens.saturating_sub(self.context_overlap);
+        let decoded = self.tokenizer.decode(&self.buffer[overlap_start..]);
+
+        // No guaranteed token-to-text alignment, but decoding is cheap to figure out overlap
+        let overlap_decoded = self
+            .tokenizer
+            .decode(&self.buffer[overlap_start..self.emitted_tokens]);
+
+        match decoded.get(overlap_decoded.len()..) {
+            Some(new_text) if !new_text.is_empty() => {
+                self.emitted_tokens = self.buffer.len();
+                Some(new_text.to_string())
+            }
+            _ => None,
+        }
+    }
+}

--- a/crates/burn-lm-llama/src/nn/llama/base.rs
+++ b/crates/burn-lm-llama/src/nn/llama/base.rs
@@ -17,7 +17,7 @@ use crate::{
 };
 
 #[cfg(feature = "tiny")]
-use crate::tokenizer::SentiencePieceTokenizer;
+use crate::tokenizer::SentencePieceTokenizer;
 #[cfg(feature = "llama3")]
 use crate::tokenizer::Tiktoken;
 
@@ -237,12 +237,12 @@ impl LlamaConfig {
         tokenizer_path: &str,
         max_seq_len: usize,
         device: &Device<B>,
-    ) -> Result<Llama<B, SentiencePieceTokenizer>, String> {
+    ) -> Result<Llama<B, SentencePieceTokenizer>, String> {
         use burn::record::NamedMpkFileRecorder;
 
         let llama = Self::tiny_llama(tokenizer_path)
             .with_max_seq_len(max_seq_len)
-            .init::<B, SentiencePieceTokenizer>(device)?;
+            .init::<B, SentencePieceTokenizer>(device)?;
 
         let recorder = NamedMpkFileRecorder::<HalfPrecisionSettings>::new();
         let llama = llama

--- a/crates/burn-lm-llama/src/nn/llama/pretrained.rs
+++ b/crates/burn-lm-llama/src/nn/llama/pretrained.rs
@@ -6,7 +6,7 @@ use super::{Llama, LlamaConfig, LlamaVersion, TinyLlamaVersion};
 use crate::tokenizer::Tiktoken;
 
 #[cfg(feature = "tiny")]
-use crate::tokenizer::SentiencePieceTokenizer;
+use crate::tokenizer::SentencePieceTokenizer;
 
 /// Pre-trained model metadata.
 pub struct Pretrained {
@@ -280,7 +280,7 @@ impl LlamaConfig {
     pub fn tiny_llama_pretrained<B: Backend>(
         max_seq_len: usize,
         device: &Device<B>,
-    ) -> Result<Llama<B, SentiencePieceTokenizer>, String> {
+    ) -> Result<Llama<B, SentencePieceTokenizer>, String> {
         // TinyLlama models support context length up to 2K tokens.
 
         check_context_length(max_seq_len, 2 * 1024);

--- a/crates/burn-lm-llama/src/server/tiny.rs
+++ b/crates/burn-lm-llama/src/server/tiny.rs
@@ -5,7 +5,7 @@ use std::sync::{Arc, Mutex};
 use crate::{
     generation::{GenerationError, Sampler, TopP},
     pretrained::ModelMeta,
-    tokenizer::SentiencePieceTokenizer,
+    tokenizer::SentencePieceTokenizer,
     Llama, LlamaConfig, TinyLlamaVersion,
 };
 use burn::prelude::Backend;
@@ -38,7 +38,7 @@ pub struct TinyLlamaServerConfig {
 )]
 pub struct TinyLlamaServer<B: Backend> {
     config: TinyLlamaServerConfig,
-    model: Option<Arc<Mutex<Llama<B, SentiencePieceTokenizer>>>>,
+    model: Option<Arc<Mutex<Llama<B, SentencePieceTokenizer>>>>,
 }
 
 impl TinyLlamaServer<InferenceBackend> {

--- a/crates/burn-lm-llama/src/tokenizer/base.rs
+++ b/crates/burn-lm-llama/src/tokenizer/base.rs
@@ -8,11 +8,11 @@ pub trait Tokenizer: Send + Sync + Clone {
     fn encode(&self, text: &str, bos: bool, eos: bool) -> Vec<u32>;
 
     /// Decode a list of token identifiers into a string.
-    fn decode(&self, tokens: Vec<u32>) -> String;
+    fn decode(&self, tokens: &[u32]) -> String;
 
     /// Beginning of sentence token.
     fn bos(&self) -> String {
-        self.decode(vec![self.bos_id()])
+        self.decode(&[self.bos_id()])
     }
 
     /// Beginning of sentence token identifier.
@@ -20,7 +20,7 @@ pub trait Tokenizer: Send + Sync + Clone {
 
     /// End of sentence token.
     fn eos(&self) -> String {
-        self.decode(vec![self.eos_id()])
+        self.decode(&[self.eos_id()])
     }
 
     /// End of sentence token identifier.
@@ -28,4 +28,10 @@ pub trait Tokenizer: Send + Sync + Clone {
 
     /// Stop token identifiers.
     fn stop_ids(&self) -> Vec<u32>;
+
+    /// Number of tokens needed as context for incremental streaming decoding.
+    /// Default is 0 (no context/buffering needed).
+    fn streaming_context_size(&self) -> usize {
+        0
+    }
 }

--- a/crates/burn-lm-llama/src/tokenizer/byte.rs
+++ b/crates/burn-lm-llama/src/tokenizer/byte.rs
@@ -31,7 +31,7 @@ impl Tokenizer for ByteTokenizer {
             .collect()
     }
 
-    fn decode(&self, tokens: Vec<u32>) -> String {
+    fn decode(&self, tokens: &[u32]) -> String {
         format!("{tokens:?}")
     }
 

--- a/crates/burn-lm-llama/src/tokenizer/sentence_piece.rs
+++ b/crates/burn-lm-llama/src/tokenizer/sentence_piece.rs
@@ -36,10 +36,8 @@ impl Tokenizer for SentencePieceTokenizer {
             .collect()
     }
 
-    fn decode(&self, tokens: Vec<u32>) -> String {
-        self.bpe
-            .decode(&tokens.into_iter().collect::<Vec<u32>>(), true)
-            .unwrap()
+    fn decode(&self, tokens: &[u32]) -> String {
+        self.bpe.decode(tokens, false).unwrap()
     }
 
     fn bos_id(&self) -> u32 {
@@ -52,5 +50,11 @@ impl Tokenizer for SentencePieceTokenizer {
 
     fn stop_ids(&self) -> Vec<u32> {
         vec![self.eos_id()]
+    }
+
+    fn streaming_context_size(&self) -> usize {
+        // SentencePiece tokens represent subwords with special markers (e.g., _ suffix for spaces),
+        // requiring a short token buffer for correct incremental decoding.
+        4 // should be good enough for spacing + utf-8 decoding
     }
 }

--- a/crates/burn-lm-llama/src/tokenizer/sentence_piece.rs
+++ b/crates/burn-lm-llama/src/tokenizer/sentence_piece.rs
@@ -6,13 +6,13 @@ const BOS_TOKEN_ID: u32 = 1;
 const EOS_TOKEN_ID: u32 = 2;
 
 #[derive(Debug, Clone)]
-pub struct SentiencePieceTokenizer {
+pub struct SentencePieceTokenizer {
     bpe: BaseTokenizer,
     bos_token_id: u32,
     eos_token_id: u32,
 }
 
-impl Tokenizer for SentiencePieceTokenizer {
+impl Tokenizer for SentencePieceTokenizer {
     /// Load the [SentenciePiece](https://github.com/google/sentencepiece) tokenizer.
     fn new(tokenizer_path: &str) -> Result<Self, String> {
         let bpe = BaseTokenizer::from_file(tokenizer_path).map_err(|e| e.to_string())?;

--- a/crates/burn-lm-llama/src/tokenizer/tiktoken.rs
+++ b/crates/burn-lm-llama/src/tokenizer/tiktoken.rs
@@ -109,9 +109,9 @@ impl Tokenizer for Tiktoken {
             .collect()
     }
 
-    fn decode(&self, tokens: Vec<u32>) -> String {
+    fn decode(&self, tokens: &[u32]) -> String {
         self.bpe
-            .decode(tokens.into_iter().map(|t| t as usize).collect())
+            .decode(tokens.iter().map(|&t| t as usize).collect())
             .expect("Should decode tokens")
     }
 


### PR DESCRIPTION
Fixes TinyLlama issues with streaming decoding. Unlike Tiktoken, sentence piece tokenizer is not entirely "stateless" (for lack of a better word). It needs to know about token boundaries and merges across tokens (e.g., spaces are encoded with a prefixed `_` char, and the decoder applies post-processing that also strips the prefix when it's at the beginning of the decoded token)


- Fixed `SentiencePiece` -> `SentencePiece`
- Added `StreamingDecoder` for buffered incremental decoding (based on context size, defaults to 0 for other tokenizers)