### PR TITLE
Update model schema and macro docs

### DIFF
--- a/crates/burn-lm-http/src/schemas/model_schemas.rs
+++ b/crates/burn-lm-http/src/schemas/model_schemas.rs
@@ -13,11 +13,11 @@ pub struct ModelSchema {
 
 impl From<&Box<dyn InferencePlugin>> for ModelSchema {
     fn from(plugin: &Box<dyn InferencePlugin>) -> Self {
-        let created_date = NaiveDate::parse_from_str(plugin.model_creation_date(), "%m/%d/%Y")
-            .expect("Valid date format expected (MM/DD/YYYY)");
+        let created_date = NaiveDate::parse_from_str(plugin.model_creation_date(), "%Y/%m/%d")
+            .expect("Valid date format expected (YYYY/MM/DD)");
         let created = created_date
             .and_hms_opt(0, 0, 0)
-            .expect("Should be a valid time using MM/DD/YYYY format")
+            .expect("Should be a valid time using YYYY/MM/DD format")
             .and_utc()
             .timestamp() as u32;
         Self {

--- a/crates/burn-lm-http/src/schemas/model_schemas.rs
+++ b/crates/burn-lm-http/src/schemas/model_schemas.rs
@@ -8,7 +8,7 @@ pub struct ModelSchema {
     pub id: String,
     pub created: u32,
     pub object: String,
-    pub owned_by: String,
+    pub created_by: String,
 }
 
 impl From<&Box<dyn InferencePlugin>> for ModelSchema {
@@ -23,7 +23,7 @@ impl From<&Box<dyn InferencePlugin>> for ModelSchema {
         Self {
             id: plugin.model_name().to_string(),
             object: "model".to_string(),
-            owned_by: plugin.owned_by().to_string(),
+            created_by: plugin.created_by().to_string(),
             created,
         }
     }

--- a/crates/burn-lm-inference/src/client.rs
+++ b/crates/burn-lm-inference/src/client.rs
@@ -16,7 +16,7 @@ pub struct InferenceClient<Server: InferenceServer + 'static, Channel: 'static> 
     model_name: &'static str,
     model_cli_param_name: &'static str,
     model_creation_date: &'static str,
-    owned_by: &'static str,
+    created_by: &'static str,
     create_cli_flags_fn: CreateCliFlagsFn,
     channel: Channel,
     _phantom_server: PhantomData<Server>,
@@ -32,7 +32,7 @@ where
         model_name: &'static str,
         model_cli_param_name: &'static str,
         model_creation_date: &'static str,
-        owned_by: &'static str,
+        created_by: &'static str,
         create_cli_flags_fn: CreateCliFlagsFn,
         channel: Channel,
     ) -> Self {
@@ -40,7 +40,7 @@ where
             model_name,
             model_cli_param_name,
             model_creation_date,
-            owned_by,
+            created_by,
             create_cli_flags_fn,
             channel,
             _phantom_server: PhantomData,
@@ -132,8 +132,8 @@ where
         self.model_creation_date
     }
 
-    fn owned_by(&self) -> &'static str {
-        self.owned_by
+    fn created_by(&self) -> &'static str {
+        self.created_by
     }
 
     fn create_cli_flags_fn(&self) -> CreateCliFlagsFn {

--- a/crates/burn-lm-inference/src/plugin.rs
+++ b/crates/burn-lm-inference/src/plugin.rs
@@ -9,7 +9,7 @@ pub trait InferencePlugin: Send + Sync + Debug {
     fn model_name(&self) -> &'static str;
     fn model_cli_param_name(&self) -> &'static str;
     fn model_creation_date(&self) -> &'static str;
-    fn owned_by(&self) -> &'static str;
+    fn created_by(&self) -> &'static str;
     fn create_cli_flags_fn(&self) -> CreateCliFlagsFn;
     fn downloader(&self) -> Option<fn() -> InferenceResult<Option<Stats>>>;
     fn is_downloaded(&self) -> bool;

--- a/crates/burn-lm-llama/src/server/llama3.rs
+++ b/crates/burn-lm-llama/src/server/llama3.rs
@@ -34,7 +34,7 @@ pub struct Llama3ServerConfig {
 #[inference_server(
     model_name = "Llama 3 (8B Instruct)",
     model_cli_param_name = "llama3",
-    model_creation_date = "05/01/2024",
+    model_creation_date = "2024/04/18",
     owned_by = "Tracel Technologies Inc."
 )]
 pub struct Llama3InstructServer<B: Backend> {
@@ -129,7 +129,7 @@ impl InferenceServer for Llama3InstructServer<InferenceBackend> {
 #[inference_server(
     model_name = "Llama 3.1 (8B Instruct)",
     model_cli_param_name = "llama31",
-    model_creation_date = "05/01/2024",
+    model_creation_date = "2024/07/23",
     owned_by = "Tracel Technologies Inc."
 )]
 pub struct Llama31InstructServer<B: Backend> {
@@ -197,7 +197,7 @@ impl InferenceServer for Llama31InstructServer<InferenceBackend> {
 #[inference_server(
     model_name = "Llama 3.2 (1B Instruct)",
     model_cli_param_name = "llama32",
-    model_creation_date = "05/01/2024",
+    model_creation_date = "2024/09/25",
     owned_by = "Tracel Technologies Inc."
 )]
 pub struct Llama321bInstructServer<B: Backend> {
@@ -265,7 +265,7 @@ impl InferenceServer for Llama321bInstructServer<InferenceBackend> {
 #[inference_server(
     model_name = "Llama 3.2 (3B Instruct)",
     model_cli_param_name = "llama32-3b",
-    model_creation_date = "05/01/2024",
+    model_creation_date = "2024/09/25",
     owned_by = "Tracel Technologies Inc."
 )]
 pub struct Llama323bInstructServer<B: Backend> {

--- a/crates/burn-lm-llama/src/server/llama3.rs
+++ b/crates/burn-lm-llama/src/server/llama3.rs
@@ -35,7 +35,7 @@ pub struct Llama3ServerConfig {
     model_name = "Llama 3 (8B Instruct)",
     model_cli_param_name = "llama3",
     model_creation_date = "2024/04/18",
-    owned_by = "Tracel Technologies Inc."
+    created_by = "Meta"
 )]
 pub struct Llama3InstructServer<B: Backend> {
     config: Llama3ServerConfig,
@@ -130,7 +130,7 @@ impl InferenceServer for Llama3InstructServer<InferenceBackend> {
     model_name = "Llama 3.1 (8B Instruct)",
     model_cli_param_name = "llama31",
     model_creation_date = "2024/07/23",
-    owned_by = "Tracel Technologies Inc."
+    created_by = "Meta"
 )]
 pub struct Llama31InstructServer<B: Backend> {
     config: Llama3ServerConfig,
@@ -198,7 +198,7 @@ impl InferenceServer for Llama31InstructServer<InferenceBackend> {
     model_name = "Llama 3.2 (1B Instruct)",
     model_cli_param_name = "llama32",
     model_creation_date = "2024/09/25",
-    owned_by = "Tracel Technologies Inc."
+    created_by = "Meta"
 )]
 pub struct Llama321bInstructServer<B: Backend> {
     config: Llama3ServerConfig,
@@ -266,7 +266,7 @@ impl InferenceServer for Llama321bInstructServer<InferenceBackend> {
     model_name = "Llama 3.2 (3B Instruct)",
     model_cli_param_name = "llama32-3b",
     model_creation_date = "2024/09/25",
-    owned_by = "Tracel Technologies Inc."
+    created_by = "Meta"
 )]
 pub struct Llama323bInstructServer<B: Backend> {
     config: Llama3ServerConfig,

--- a/crates/burn-lm-llama/src/server/tiny.rs
+++ b/crates/burn-lm-llama/src/server/tiny.rs
@@ -33,7 +33,7 @@ pub struct TinyLlamaServerConfig {
 #[derive(InferenceServer, Clone, Default, Debug)]
 #[inference_server(
     model_name = "TinyLlama",
-    model_creation_date = "05/01/2024",
+    model_creation_date = "30/12/2023",
     owned_by = "Tracel Technologies Inc."
 )]
 pub struct TinyLlamaServer<B: Backend> {

--- a/crates/burn-lm-llama/src/server/tiny.rs
+++ b/crates/burn-lm-llama/src/server/tiny.rs
@@ -33,9 +33,10 @@ pub struct TinyLlamaServerConfig {
 #[derive(InferenceServer, Clone, Default, Debug)]
 #[inference_server(
     model_name = "TinyLlama",
-    model_creation_date = "30/12/2023",
-    owned_by = "Tracel Technologies Inc."
+    model_creation_date = "2023/12/30",
+    created_by = "StatNLP Research Group"
 )]
+// [StatNLP Research Group](https://arxiv.org/abs/2401.02385)
 pub struct TinyLlamaServer<B: Backend> {
     config: TinyLlamaServerConfig,
     model: Option<Arc<Mutex<Llama<B, SentiencePieceTokenizer>>>>,

--- a/crates/burn-lm-macros/src/lib.rs
+++ b/crates/burn-lm-macros/src/lib.rs
@@ -245,16 +245,16 @@ pub fn inference_server(input: TokenStream) -> TokenStream {
     // handle model_creation_date
     let model_creation_date = match receiver.model_creation_date {
         Some(ref date_str) => {
-            if NaiveDate::parse_from_str(date_str, "%m/%d/%Y").is_err() {
+            if NaiveDate::parse_from_str(date_str, "%Y/%m/%d").is_err() {
                 let err_msg = format!(
-                    "Invalid 'model_creation_date': {date_str}. Must be in MM/DD/YYYY format."
+                    "Invalid 'model_creation_date': {date_str}. Must be in YYYY/MM/DD format."
                 );
                 return TokenStream::from(quote! { compile_error!(#err_msg) });
             }
             quote! { #date_str }
         }
         None => {
-            let err_msg = "You must provide a 'model_creation_date' using '#[inference_server(model_creation_date=\"MM/DD/YYYY\")]'";
+            let err_msg = "You must provide a 'model_creation_date' using '#[inference_server(model_creation_date=\"YYYY/MM/DD\")]'";
             return TokenStream::from(quote! { compile_error!(#err_msg) });
         }
     };

--- a/crates/burn-lm-parrot/src/lib.rs
+++ b/crates/burn-lm-parrot/src/lib.rs
@@ -39,7 +39,7 @@ pub struct ParrotServerConfig {
 #[inference_server(
     model_name = "Parrot",
     model_creation_date = "2025/01/28",
-    owned_by = "Tracel Technologies Inc."
+    created_by = "Tracel Technologies Inc."
 )]
 pub struct ParrotServer<B: Backend> {
     config: ParrotServerConfig,

--- a/crates/burn-lm-parrot/src/lib.rs
+++ b/crates/burn-lm-parrot/src/lib.rs
@@ -38,7 +38,7 @@ pub struct ParrotServerConfig {
 #[derive(InferenceServer, Clone, Default, Debug)]
 #[inference_server(
     model_name = "Parrot",
-    model_creation_date = "01/28/2025",
+    model_creation_date = "2025/01/28",
     owned_by = "Tracel Technologies Inc."
 )]
 pub struct ParrotServer<B: Backend> {


### PR DESCRIPTION
Fixes #32

- Changed `model_creation_date` to `YYYY/MM/DD` format
- Renamed `owned_by` -> `created_by`
- Updated model creation dates and orgs for proper attribution
- Added `inference_server` fields doc