### PR TITLE
Fix REST token streaming for chat completions

### DIFF
--- a/crates/burn-lm-http/src/handlers/chat_handlers.rs
+++ b/crates/burn-lm-http/src/handlers/chat_handlers.rs
@@ -4,7 +4,10 @@ use axum::{
     response::{IntoResponse, Response},
     Json,
 };
-use burn_lm_inference::{InferenceJob, InferenceTask, StatEntry, TextGenerationListener};
+use burn_lm_inference::{
+    InferenceJob, InferenceTask, StatEntry, TextGenerationListener, WriteListener,
+};
+use std::io::Write;
 use tokio::sync::mpsc;
 use tokio_stream::{wrappers::ReceiverStream, StreamExt};
 
@@ -21,6 +24,35 @@ use crate::{
 };
 
 pub const REPLY_MARKER: &str = "##### Model Reply";
+
+struct SseWriter {
+    tx: mpsc::Sender<String>,
+    id: String,
+    model: String,
+    created: i64,
+}
+
+impl Write for SseWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        let text = String::from_utf8_lossy(buf);
+        let chunk = StreamingChunk::Data(ChatCompletionChunkSchema::new(
+            &self.id,
+            &self.model,
+            self.created,
+            &text,
+        ));
+
+        self.tx
+            .blocking_send(chunk.to_event_stream())
+            .map_err(|_| std::io::ErrorKind::BrokenPipe)?;
+
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
 
 pub async fn chat_completions(
     State(state): State<ModelStoreState>,
@@ -172,7 +204,13 @@ async fn handle_streaming_response(
                 .for_each(|m| m.cleanup(REPLY_MARKER, burn_lm_inference::STATS_MARKER));
             tracing::debug!("Cleaned up messages: {:?}", messages);
             let task = InferenceTask::Context(messages);
-            let (job, handle) = InferenceJob::create(task, TextGenerationListener::default());
+            let listener = WriteListener::new(SseWriter {
+                tx: tx.clone(),
+                id: id.clone(),
+                model: model.to_string(),
+                created: now,
+            });
+            let (job, handle) = InferenceJob::create(task, listener);
             let stats = tokio::task::spawn_blocking({
                 let plugin = plugin.clone();
                 move || plugin.run_job(job).expect("should generate answer")
@@ -180,14 +218,13 @@ async fn handle_streaming_response(
             .await
             .expect("should complete answer generation");
 
-            let content = handle.join();
-            let content = format!("{}\n\n{}", content, stats.display_stats());
-            tracing::debug!("Answer: {}", content);
+            handle.join();
+            let stats = format!("\n\n{}", stats.display_stats());
             let chunk =
-                StreamingChunk::Data(ChatCompletionChunkSchema::new(&id, model, now, &content));
+                StreamingChunk::Data(ChatCompletionChunkSchema::new(&id, model, now, &stats));
             tx.send(chunk.to_event_stream())
                 .await
-                .expect("should send answer chunk");
+                .expect("should send stats chunk");
 
             // Done chunk
             let done_chunk = StreamingChunk::Done;
@@ -272,23 +309,26 @@ mod tests {
     async fn rest_generation_streams_text_as_soon_as_it_is_emitted() {
         let (tx, mut rx) = mpsc::channel(1);
         let task = InferenceTask::Prompt("prompt".to_string());
-        let (job, handle) = InferenceJob::create(task, TextGenerationListener::default());
+        let listener = WriteListener::new(SseWriter {
+            tx,
+            id: "chatcmpl-test".to_string(),
+            model: "test-model".to_string(),
+            created: 42,
+        });
+        let (job, handle) = InferenceJob::create(task, listener);
 
         std::thread::spawn(move || {
             // This simulates the model emitting a token while generation is still running.
             job.emitter
                 .completed(GeneratedItem::Text("first".to_string()));
             std::thread::sleep(Duration::from_millis(200));
-
-            // This is the current REST behavior: only after generation completes do we join the
-            // buffered listener and send content to the SSE response.
-            tx.blocking_send(handle.join()).unwrap();
+            handle.join();
         });
 
         let first = tokio::time::timeout(Duration::from_millis(50), rx.recv())
             .await
             .expect("REST should stream emitted text without waiting for generation to finish")
             .expect("stream should still be open");
-        assert_eq!(first, "first");
+        assert!(first.contains("\"content\":\"first\""));
     }
 }

--- a/crates/burn-lm-http/src/handlers/chat_handlers.rs
+++ b/crates/burn-lm-http/src/handlers/chat_handlers.rs
@@ -220,3 +220,75 @@ async fn handle_streaming_response(
     )
         .into_response())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use burn_lm_inference::{GeneratedItem, WriteListener};
+    use std::io::Write;
+    use std::time::Duration;
+
+    struct ChannelWriter {
+        tx: mpsc::Sender<String>,
+    }
+
+    impl Write for ChannelWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            let text = String::from_utf8_lossy(buf).to_string();
+            self.tx
+                .blocking_send(text)
+                .map_err(|_| std::io::ErrorKind::BrokenPipe)?;
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn write_listener_streams_text_as_soon_as_it_is_emitted() {
+        let (tx, mut rx) = mpsc::channel(1);
+        let task = InferenceTask::Prompt("prompt".to_string());
+        let listener = WriteListener::new(ChannelWriter { tx });
+        let (job, handle) = InferenceJob::create(task, listener);
+
+        std::thread::spawn(move || {
+            // This simulates the model emitting a token while generation is still running.
+            job.emitter
+                .completed(GeneratedItem::Text("first".to_string()));
+            std::thread::sleep(Duration::from_millis(200));
+            handle.join();
+        });
+
+        let first = tokio::time::timeout(Duration::from_millis(50), rx.recv())
+            .await
+            .expect("write listener should stream emitted text without waiting to finish")
+            .expect("stream should still be open");
+        assert_eq!(first, "first");
+    }
+
+    #[tokio::test]
+    async fn rest_generation_streams_text_as_soon_as_it_is_emitted() {
+        let (tx, mut rx) = mpsc::channel(1);
+        let task = InferenceTask::Prompt("prompt".to_string());
+        let (job, handle) = InferenceJob::create(task, TextGenerationListener::default());
+
+        std::thread::spawn(move || {
+            // This simulates the model emitting a token while generation is still running.
+            job.emitter
+                .completed(GeneratedItem::Text("first".to_string()));
+            std::thread::sleep(Duration::from_millis(200));
+
+            // This is the current REST behavior: only after generation completes do we join the
+            // buffered listener and send content to the SSE response.
+            tx.blocking_send(handle.join()).unwrap();
+        });
+
+        let first = tokio::time::timeout(Duration::from_millis(50), rx.recv())
+            .await
+            .expect("REST should stream emitted text without waiting for generation to finish")
+            .expect("stream should still be open");
+        assert_eq!(first, "first");
+    }
+}

--- a/crates/burn-lm-inference/src/job.rs
+++ b/crates/burn-lm-inference/src/job.rs
@@ -123,38 +123,75 @@ pub trait InferenceJobListener: Send + 'static {
     fn on_finished(self) -> Self::CompletedItem;
 }
 
+/// A listener that writes intermediary [generated items](GeneratedItem) to a writer as soon as
+/// they are produced.
+pub struct WriteListener<W: Write + Send + 'static> {
+    writer: W,
+}
+
+impl<W: Write + Default + Send + 'static> Default for WriteListener<W> {
+    fn default() -> Self {
+        Self::new(W::default())
+    }
+}
+
+impl<W: Write + Send + 'static> WriteListener<W> {
+    pub fn new(writer: W) -> Self {
+        Self { writer }
+    }
+}
+
+impl<W: Write + Send + 'static> InferenceJobListener for WriteListener<W> {
+    type CompletedItem = W;
+
+    fn on_text(&mut self, text: String) {
+        write!(self.writer, "{text}").unwrap();
+        self.writer.flush().unwrap();
+    }
+
+    fn on_finished(self) -> Self::CompletedItem {
+        self.writer
+    }
+}
+
 #[derive(Default)]
 /// The text generation listener accumulate the generated text in a string that can be
 /// obtained at the end of the job with the [handle finished method](JobHandle::finished).
 pub struct TextGenerationListener {
-    value: String,
+    inner: WriteListener<Vec<u8>>,
 }
 
 impl InferenceJobListener for TextGenerationListener {
     type CompletedItem = String;
 
     fn on_text(&mut self, text: String) {
-        self.value += &text;
+        self.inner.on_text(text);
     }
 
     fn on_finished(self) -> Self::CompletedItem {
-        self.value
+        String::from_utf8_lossy(&self.inner.on_finished()).into_owned()
     }
 }
 
-#[derive(Default)]
 /// The stdout listener directly writes the intermediary [generated item](GeneratedItem) to
 /// [std::io::stdout].
-pub struct StdOutListener {}
+pub struct StdOutListener {
+    inner: WriteListener<std::io::Stdout>,
+}
+
+impl Default for StdOutListener {
+    fn default() -> Self {
+        Self {
+            inner: WriteListener::new(std::io::stdout()),
+        }
+    }
+}
 
 impl InferenceJobListener for StdOutListener {
     type CompletedItem = ();
 
     fn on_text(&mut self, text: String) {
-        let mut io = std::io::stdout();
-
-        write!(io, "{text}").unwrap();
-        io.flush().unwrap();
+        self.inner.on_text(text);
     }
 
     fn on_finished(self) -> Self::CompletedItem {}


### PR DESCRIPTION
## Summary

Fixes REST chat completion streaming so generated model text is emitted as SSE chunks while inference is still running, instead of buffering the full answer until generation completes.

The lower-level inference API already emits text incrementally through `GeneratedItemEmitter`, and the CLI chat path already benefits from that listener flow. This PR wires the REST streaming handler into the same event path by adding a reusable writer-backed listener and an HTTP SSE writer.

Closes #31.

## What Changed

- Added `WriteListener<W>` as a reusable `InferenceJobListener` that writes each generated text item immediately to any `std::io::Write`.
- Refactored `TextGenerationListener` and `StdOutListener` to use `WriteListener`.
- Added an HTTP `SseWriter` that converts generated text writes into OpenAI-style `chat.completion.chunk` SSE events.
- Updated the REST streaming handler to use `WriteListener<SseWriter>` for generation.
- Kept post-generation stats and `data: [DONE]` at the end of the stream.
- Added tests that validate both the writer listener behavior and the HTTP SSE streaming hook.

## Why

Before this change, `stream: true` returned an SSE response, but generation still used `TextGenerationListener`, waited for `plugin.run_job(job)`, then called `handle.join()` and sent the entire generated answer as a single chunk.

With this change, each generated text item is converted to an SSE chunk as soon as the inference listener receives it.

## Testing

Automated:

```sh
cargo test --package burn-lm-inference
cargo test --package burn-lm-http chat_handlers::tests
```

Manual server command:

```sh
cargo run --release --package burn-lm-http --bin burn-lm-http \
  --features burn-lm-inference/metal,burn-lm-inference/f32 \
  -- run --port 3001
```

Manual request:

```sh
time curl -N -sS http://127.0.0.1:3001/v1/chat/completions \
  -H 'Content-Type: application/json' \
  -d '{
    "model": "TinyLlama",
    "stream": true,
    "messages": [{"role": "user", "content": "Count from one to twenty, slowly.", "refusal": null}],
    "max_tokens": 80,
    "temperature": 0.0
  }'
```

Manual curl output:

```text
data: {"id":"chatcmpl-0","object":"chat.completion.chunk","created":1780491857,"model":"TinyLlama","choices":[{"index":0,"delta":{"role":null,"content":"```Burn LM\nloading model 'TinyLlama'... "},"logprobs":null,"finish_reason":null}],"usage":null,"system_fingerprint":"","service_tier":null}

data: {"id":"chatcmpl-0","object":"chat.completion.chunk","created":1780491857,"model":"TinyLlama","choices":[{"index":0,"delta":{"role":null,"content":"model loaded ! ✓ (1.81s)\n```\n\n"},"logprobs":null,"finish_reason":null}],"usage":null,"system_fingerprint":"","service_tier":null}

data: {"id":"chatcmpl-0","object":"chat.completion.chunk","created":1780491857,"model":"TinyLlama","choices":[{"index":0,"delta":{"role":null,"content":"\n##### Model Reply\n"},"logprobs":null,"finish_reason":null}],"usage":null,"system_fingerprint":"","service_tier":null}

data: {"id":"chatcmpl-0","object":"chat.completion.chunk","created":1780491857,"model":"TinyLlama","choices":[{"index":0,"delta":{"role":null,"content":"1. One\n"},"logprobs":null,"finish_reason":null}],"usage":null,"system_fingerprint":"","service_tier":null}

data: {"id":"chatcmpl-0","object":"chat.completion.chunk","created":1780491857,"model":"TinyLlama","choices":[{"index":0,"delta":{"role":null,"content":"2. Two\n"},"logprobs":null,"finish_reason":null}],"usage":null,"system_fingerprint":"","service_tier":null}

data: {"id":"chatcmpl-0","object":"chat.completion.chunk","created":1780491857,"model":"TinyLlama","choices":[{"index":0,"delta":{"role":null,"content":"3. Three\n"},"logprobs":null,"finish_reason":null}],"usage":null,"system_fingerprint":"","service_tier":null}

data: {"id":"chatcmpl-0","object":"chat.completion.chunk","created":1780491857,"model":"TinyLlama","choices":[{"index":0,"delta":{"role":null,"content":"4. Four\n"},"logprobs":null,"finish_reason":null}],"usage":null,"system_fingerprint":"","service_tier":null}

data: {"id":"chatcmpl-0","object":"chat.completion.chunk","created":1780491857,"model":"TinyLlama","choices":[{"index":0,"delta":{"role":null,"content":"5. Five\n"},"logprobs":null,"finish_reason":null}],"usage":null,"system_fingerprint":"","service_tier":null}

data: {"id":"chatcmpl-0","object":"chat.completion.chunk","created":1780491857,"model":"TinyLlama","choices":[{"index":0,"delta":{"role":null,"content":"6. Six\n"},"logprobs":null,"finish_reason":null}],"usage":null,"system_fingerprint":"","service_tier":null}

data: {"id":"chatcmpl-0","object":"chat.completion.chunk","created":1780491857,"model":"TinyLlama","choices":[{"index":0,"delta":{"role":null,"content":"7. Seven\n"},"logprobs":null,"finish_reason":null}],"usage":null,"system_fingerprint":"","service_tier":null}

data: {"id":"chatcmpl-0","object":"chat.completion.chunk","created":1780491857,"model":"TinyLlama","choices":[{"index":0,"delta":{"role":null,"content":"8. Eight"},"logprobs":null,"finish_reason":null}],"usage":null,"system_fingerprint":"","service_tier":null}

data: {"id":"chatcmpl-0","object":"chat.completion.chunk","created":1780491857,"model":"TinyLlama","choices":[{"index":0,"delta":{"role":null,"content":"\n9. N"},"logprobs":null,"finish_reason":null}],"usage":null,"system_fingerprint":"","service_tier":null}

data: {"id":"chatcmpl-0","object":"chat.completion.chunk","created":1780491857,"model":"TinyLlama","choices":[{"index":0,"delta":{"role":null,"content":"ine\n10"},"logprobs":null,"finish_reason":null}],"usage":null,"system_fingerprint":"","service_tier":null}

data: {"id":"chatcmpl-0","object":"chat.completion.chunk","created":1780491857,"model":"TinyLlama","choices":[{"index":0,"delta":{"role":null,"content":". Ten\n1"},"logprobs":null,"finish_reason":null}],"usage":null,"system_fingerprint":"","service_tier":null}

data: {"id":"chatcmpl-0","object":"chat.completion.chunk","created":1780491857,"model":"TinyLlama","choices":[{"index":0,"delta":{"role":null,"content":"1. Eleven"},"logprobs":null,"finish_reason":null}],"usage":null,"system_fingerprint":"","service_tier":null}

data: {"id":"chatcmpl-0","object":"chat.completion.chunk","created":1780491857,"model":"TinyLlama","choices":[{"index":0,"delta":{"role":null,"content":"\n12."},"logprobs":null,"finish_reason":null}],"usage":null,"system_fingerprint":"","service_tier":null}

data: {"id":"chatcmpl-0","object":"chat.completion.chunk","created":1780491857,"model":"TinyLlama","choices":[{"index":0,"delta":{"role":null,"content":" Twelve\n1"},"logprobs":null,"finish_reason":null}],"usage":null,"system_fingerprint":"","service_tier":null}

data: {"id":"chatcmpl-0","object":"chat.completion.chunk","created":1780491857,"model":"TinyLlama","choices":[{"index":0,"delta":{"role":null,"content":"3. Thir"},"logprobs":null,"finish_reason":null}],"usage":null,"system_fingerprint":"","service_tier":null}

data: {"id":"chatcmpl-0","object":"chat.completion.chunk","created":1780491857,"model":"TinyLlama","choices":[{"index":0,"delta":{"role":null,"content":"teen\n14"},"logprobs":null,"finish_reason":null}],"usage":null,"system_fingerprint":"","service_tier":null}

data: {"id":"chatcmpl-0","object":"chat.completion.chunk","created":1780491857,"model":"TinyLlama","choices":[{"index":0,"delta":{"role":null,"content":". Fourteen\n"},"logprobs":null,"finish_reason":null}],"usage":null,"system_fingerprint":"","service_tier":null}

data: {"id":"chatcmpl-0","object":"chat.completion.chunk","created":1780491857,"model":"TinyLlama","choices":[{"index":0,"delta":{"role":null,"content":"15. Fif"},"logprobs":null,"finish_reason":null}],"usage":null,"system_fingerprint":"","service_tier":null}

data: {"id":"chatcmpl-0","object":"chat.completion.chunk","created":1780491857,"model":"TinyLlama","choices":[{"index":0,"delta":{"role":null,"content":"teen\n16"},"logprobs":null,"finish_reason":null}],"usage":null,"system_fingerprint":"","service_tier":null}

data: {"id":"chatcmpl-0","object":"chat.completion.chunk","created":1780491857,"model":"TinyLlama","choices":[{"index":0,"delta":{"role":null,"content":"\n\n\n##### BurnLM Stats\n| Statistic Name     | Value |\n|--------------------|-------|\n| Inference Duration | 8.04s |\n| Tokens Count       |    79 |\n| Tokens Per Second  |  9.82 |\n| Total Duration     | 8.04s |"},"logprobs":null,"finish_reason":null}],"usage":null,"system_fingerprint":"","service_tier":null}

data: [DONE]

curl -N -sS http://127.0.0.1:3001/v1/chat/completions -H -d  0.00s user 0.01s system 0% cpu 9.872 total
```

Manual server output:

```text
Compiling burn-lm-inference v0.0.1 (/Users/nicolas/devel/burn-lm/crates/burn-lm-inference)
Compiling burn-lm-llama v0.0.1 (/Users/nicolas/devel/burn-lm/crates/burn-lm-llama)
Compiling burn-lm-parrot v0.0.1 (/Users/nicolas/devel/burn-lm/crates/burn-lm-parrot)
Compiling burn-lm-registry v0.0.1 (/Users/nicolas/devel/burn-lm/crates/burn-lm-registry)
Compiling burn-lm-http v0.0.1 (/Users/nicolas/devel/burn-lm/crates/burn-lm-http)
Finished `release` profile [optimized] target(s) in 36.14s
Running `target/release/burn-lm-http run --port 3001`
2026-06-03T13:04:16.445336Z  INFO burn_lm_http::app: Starting server on port '127.0.0.1:3001'...
2026-06-03T13:04:16.445958Z  INFO burn_lm_http::app: Server started! (press CTRL+C to exit)
2026-06-03T13:04:17.587831Z DEBUG http_request{...}: burn_lm_http::app: incoming request request_id="4b2542ac-a4b7-4bad-9cbc-6b931f3933ef" method=POST uri=/v1/chat/completions
2026-06-03T13:04:17.587967Z DEBUG http_request{...}: burn_lm_http::handlers::chat_handlers: Received JSON payload: ChatCompletionRequestSchema { model: "TinyLlama", messages: [ChoiceMessageSchema { role: User, content: "Count from one to twenty, slowly.", refusal: None }], params: ChatCompletionParamsSchema { seed: None, temperature: Some(0.0), top_p: None, max_tokens: Some(80) }, stream: true }
2026-06-03T13:04:17.587992Z  INFO http_request{...}: burn_lm_http::app: sent response request_id="4b2542ac-a4b7-4bad-9cbc-6b931f3933ef" latency=0ms status=200
2026-06-03T13:04:17.588156Z DEBUG burn_lm_http::handlers::chat_handlers: Loading model 'TinyLlama'
2026-06-03T13:04:19.399860Z DEBUG burn_lm_http::handlers::chat_handlers: Model loaded 'TinyLlama'
2026-06-03T13:04:19.399895Z DEBUG burn_lm_http::handlers::chat_handlers: Cleaned up messages: [Message { role: User, content: "Count from one to twenty, slowly.", refusal: None }]
2026-06-03T13:04:27.445392Z DEBUG http_request{...}: tower_http::trace::on_eos: end of stream stream_duration=9857 ms
```

The manual result shows the REST endpoint sends generated text progressively as separate SSE chunks before the final stats chunk and `data: [DONE]`.
