### PR TITLE
fix: Llama generation leaking kv-cache across calls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,10 +65,10 @@ async-trait = "0.1.88"
 tokio = { version = "1.42", features = ["full"] }
 tokio-stream = "0.1"
 tower-http = { version = "0.6", features = [
-"fs",
-"cors",
-"trace",
-"request-id",
+    "fs",
+    "cors",
+    "trace",
+    "request-id",
 ] }
 utoipa = { version = "5.3", features = ["axum_extras"] }
 utoipa-swagger-ui = { version = "9.0", features = ["axum"] }

--- a/crates/burn-lm-llama/src/generation/generate.rs
+++ b/crates/burn-lm-llama/src/generation/generate.rs
@@ -42,6 +42,8 @@ impl<T: Tokenizer + 'static> Llama<T> {
         sampler: &mut Sampler,
         emitter: GeneratedItemEmitter,
     ) -> Result<GenerationOutput, GenerationError> {
+        self.reset();
+
         let input_tokens = self.tokenize(prompt);
         let prompt_len = input_tokens.dims()[0];
 
@@ -150,5 +152,70 @@ mod tests {
         let expected = "[187][114][51][146][146][250][112][224][192][99][132][0][0][180][192][99][19][114][19][174][0][180][192][131][132][19][99][114][131][132][249][146][82][28][226][226][148][84][19][192][83][99][19][249][19][251][222][19][192][180][192][180][192][0][180][192][146][20][0][180][192][180][20]";
 
         assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn llama_generate_leaks_autoregressive_kv_cache_across_independent_generations() {
+        fn run_once(
+            llama: &mut crate::inference::Llama<ByteTokenizer>,
+            prompt: &str,
+        ) -> String {
+            let (emitter, handle) = GeneratedItemEmitter::init(TextGenerationListener::default());
+
+            // This observes streamed text, which can race with the decoder thread.
+            // Give the decoder a short grace period before finishing the listener;
+            // the emitter lifecycle should be fixed separately from this cache test.
+            llama
+                .generate(prompt, 48, 0.0, &mut Sampler::Argmax, emitter)
+                .unwrap();
+
+            // Note: I hate this, but fixing it properly would require intrusive changes to generate or even deeper.
+            // See comment above for more details.
+            std::thread::sleep(std::time::Duration::from_millis(100));
+
+            handle.join()
+        }
+
+        fn reset_generation_state(llama: &mut crate::inference::Llama<ByteTokenizer>) {
+            llama.reset();
+            // Keep the clean baseline explicit: a stateless request starts at position 0.
+            llama.pos_encoding.next_position = 0;
+            llama.pos_encoding.curr_seq_len = 0;
+            llama.pos_encoding.start_offset = 0;
+        }
+
+        let device: Device = Default::default();
+        let config = LlamaConfig::llama3_2_1b_test();
+        let mut llama = config.init::<ByteTokenizer>(&device).unwrap();
+
+        llama.model = Reinitializer::default()
+            .random_float(0, -1.0, 1.0)
+            .apply(llama.model);
+
+        let prompt_1 = "This is a deterministic stateless generation test.";
+        let prompt_2 = "A different request should not become hidden context.";
+
+        // With fixed weights, argmax sampling, and clean generation state,
+        // prompt_1 should have one deterministic answer.
+        reset_generation_state(&mut llama);
+        let expected_prompt_1 = run_once(&mut llama, prompt_1);
+
+        // Clearing generation state before another prompt_1 run gives the same baseline.
+        // This verifies that the test is deterministic when no stale state is present.
+        reset_generation_state(&mut llama);
+        let prompt_1_after_reset = run_once(&mut llama, prompt_1);
+        assert_eq!(expected_prompt_1, prompt_1_after_reset);
+
+        // Poison the model with an unrelated request, then run prompt_1 without clearing
+        // state. For a stateless API this must still match the clean prompt_1 baseline.
+        // If it differs, prompt_2's KV/position state leaked into the next request.
+        reset_generation_state(&mut llama);
+        let _ = run_once(&mut llama, prompt_2);
+        let prompt_1_after_unrelated_prompt = run_once(&mut llama, prompt_1);
+
+        assert_eq!(
+            expected_prompt_1, prompt_1_after_unrelated_prompt,
+            "Llama::generate leaks autoregressive KV cache across independent generations"
+        );
     }
 }

--- a/crates/burn-lm-llama/src/nn/llama/base.rs
+++ b/crates/burn-lm-llama/src/nn/llama/base.rs
@@ -266,6 +266,10 @@ impl LlamaConfig {
         let model = config.init(device);
         let cache = TransformerCache::new(&config, self.max_batch_size, device);
 
+        // Precompute a RoPE window larger than the KV-cache window. With the default
+        // max_seq_len=8192 this covers 40960 positions, so normal stateless requests
+        // reset before the RoPE table needs to shift. Very long single generations can
+        // still exceed this window, in which case PositionalEncodingState shifts it.
         let rope = RotaryEncodingConfig::new(
             self.max_seq_len * 5,
             self.d_model / self.num_attention_heads,

--- a/crates/burn-lm-llama/src/nn/llama/inference.rs
+++ b/crates/burn-lm-llama/src/nn/llama/inference.rs
@@ -62,7 +62,8 @@ impl<T: Tokenizer> Llama<T> {
 
     /// Reset the model state (used between generations)
     pub fn reset(&mut self) {
-        self.cache.reset()
+        self.cache.reset();
+        self.pos_encoding.reset();
     }
 
     /// Quantize the model weights.

--- a/crates/burn-lm-llama/src/nn/pos_encoding.rs
+++ b/crates/burn-lm-llama/src/nn/pos_encoding.rs
@@ -42,6 +42,17 @@ impl PositionalEncodingState {
         }
     }
 
+    pub fn reset(&mut self) {
+        // A counter-only reset is valid until the RoPE table has shifted. After a shift,
+        // table index 0 represents `start_offset` instead of absolute position 0, so
+        // stateless generation must restore the original position window.
+        self.rope.reset();
+
+        self.next_position = 0;
+        self.curr_seq_len = 0;
+        self.start_offset = 0;
+    }
+
     pub fn forward<const D: usize>(&self, x: Tensor<D>) -> Tensor<D> {
         self.rope.forward(x)
     }
@@ -218,5 +229,58 @@ mod tests {
         pos_encoding.prepare(1);
         assert_eq!(pos_encoding.position(), 33);
         assert_eq!(pos_encoding.index(), 8);
+    }
+
+    #[test]
+    fn test_rope_reset_after_shift() {
+        let device: Device = Default::default();
+
+        let max_seq_len = 16;
+        let rope = RopeConfig::new(500000.0)
+            .with_scaled(Some(RopeFrequencyScaling::new().with_scale_factor(32.)));
+        let scaling = rope.scaled.unwrap();
+        let freq_scaling_fn = move |x| scaling.freq_scaling_by_parts(x);
+
+        let rope = RotaryEncodingConfig::new(max_seq_len, 4 / 2)
+            .with_theta(rope.theta)
+            .init_with_frequency_scaling(freq_scaling_fn, &device);
+
+        let mut pos_encoding = PositionalEncodingState::new(rope);
+        let input = TestTensor::<4>::from([[
+            [[-0.60253906, -0.035308838], [0.41357422, 0.15100098]],
+            [[-0.044677734, -0.094177246], [0.60546875, 0.2442627]],
+        ]]);
+        let expected = pos_encoding.apply(input.clone()).into_data();
+
+        // Drive the state far enough to shift the cached RoPE frequencies.
+        pos_encoding.prepare(14);
+        pos_encoding.prepare(1);
+        pos_encoding.prepare(1);
+        pos_encoding.prepare(8);
+        assert_eq!(pos_encoding.start_offset, 16);
+
+        pos_encoding.reset();
+        assert_eq!(pos_encoding.position(), 0);
+        assert_eq!(pos_encoding.index(), 0);
+        assert_eq!(pos_encoding.start_offset, 0);
+
+        pos_encoding
+            .apply(input.clone())
+            .into_data()
+            .assert_approx_eq::<f32>(&expected, Tolerance::relative(0.05));
+
+        // Shift and reset a second time to ensure the saved original window wasn't
+        // aliased and mutated by the first shift.
+        pos_encoding.prepare(14);
+        pos_encoding.prepare(1);
+        pos_encoding.prepare(1);
+        pos_encoding.prepare(8);
+        assert_eq!(pos_encoding.start_offset, 16);
+
+        pos_encoding.reset();
+        pos_encoding
+            .apply(input.clone())
+            .into_data()
+            .assert_approx_eq::<f32>(&expected, Tolerance::relative(0.05));
     }
 }


### PR DESCRIPTION
## Problem

`Llama::generate` created a fresh `GenerationContext` for each call, but it reused model-owned autoregressive state across calls. In practice, an independent generation could inherit:

- transformer KV cache from the previous generation
- RoPE positional state from the previous generation

That is correct within one decode, but not across independent stateless generations. The same prompt with deterministic sampling should produce the same output regardless of which unrelated prompt ran before it.

## Fix

- Reset the Llama generation state at the start of `generate()`.
- Extend `Llama::reset()` to clear both the transformer KV cache and RoPE positional state.
- Add a regression test showing that an unrelated prompt must not affect the next stateless generation.
- Add coverage for resetting RoPE after its cached frequency window has shifted.
- Temporarily point Burn-LM at a Burn fork that includes `RotaryEncoding::reset()`.

## Notes

This depends on the upstream Burn change in [tracel-ai/burn#5042](https://github.com/tracel-ai/burn/pull/5042). Once that lands in a compatible Burn release, the temporary dependency pin can be moved back to the normal Burn dependency.

The regression test still observes output through the existing streaming emitter. That path has a separate lifecycle race where the listener can finish before the decoder thread has emitted every pending token, so the test includes a short grace period. The emitter lifecycle should be cleaned up separately.

## Test Plan

- `cargo fmt --check`
- `cargo test -p burn-lm-llama llama_generate_leaks_autoregressive_kv_cache_across_independent_generations -- --nocapture`
- `cargo test -p burn-lm-llama --lib`
