### PR TITLE
Fix Llama::generate dropping the final streamed token

### DIFF
--- a/crates/burn-lm-llama/src/generation/context.rs
+++ b/crates/burn-lm-llama/src/generation/context.rs
@@ -1,7 +1,10 @@
-use std::sync::{
-    atomic::{AtomicBool, AtomicUsize, Ordering},
-    mpsc::Sender,
-    Arc,
+use std::{
+    sync::{
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+        mpsc::Sender,
+        Arc,
+    },
+    thread::JoinHandle,
 };
 
 use burn::tensor::{Device, Int, Tensor};
@@ -11,14 +14,17 @@ use crate::tokenizer::Tokenizer;
 
 use super::StreamingDecoder;
 
-#[derive(Clone)]
 /// The text generation context, used to check when a stop token has been reached.
+///
+/// Not `Clone`: it owns the [`JoinHandle`] of the background decoder thread and is finalized via
+/// [`finish`](Self::finish), so cloning it would not make sense.
 pub struct GenerationContext {
     pub tokens: Tensor<1, Int>,
     num_tokens: usize,
     stop: Arc<AtomicBool>,
     num_generated: Arc<AtomicUsize>,
     sender: Sender<Tensor<1, Int>>,
+    decoder_handle: JoinHandle<()>,
 }
 
 impl GenerationContext {
@@ -36,7 +42,7 @@ impl GenerationContext {
         let mut generation =
             TokenGeneration::new(emitter, tokenizer, stop.clone(), num_generated.clone());
 
-        std::thread::spawn(move || {
+        let decoder_handle = std::thread::spawn(move || {
             for tokens in receiver.iter() {
                 let tokens = tokens
                     .into_data()
@@ -54,7 +60,29 @@ impl GenerationContext {
             stop,
             num_generated,
             sender,
+            decoder_handle,
         }
+    }
+
+    /// Finish the generation, ensuring every generated token has been decoded and emitted.
+    ///
+    /// Drops the channel sender so the decoder thread's `receiver.iter()` loop terminates, joins
+    /// that thread so all in-flight tokens are emitted before returning, and returns the final
+    /// number of generated tokens.
+    pub fn finish(self) -> usize {
+        let Self {
+            sender,
+            decoder_handle,
+            num_generated,
+            ..
+        } = self;
+
+        // Dropping the sender closes the channel, ending the decoder thread's `receiver.iter()`.
+        drop(sender);
+        // Join so the final in-flight token is decoded and emitted before we return.
+        decoder_handle.join().unwrap();
+
+        num_generated.load(Ordering::Relaxed)
     }
 
     /// Add generated tokens to the state (without checking for stop condition).

--- a/crates/burn-lm-llama/src/generation/generate.rs
+++ b/crates/burn-lm-llama/src/generation/generate.rs
@@ -95,7 +95,10 @@ impl<T: Tokenizer + 'static> Llama<T> {
             input_pos = input_pos.slice(t - 1..t) + 1;
         }
 
-        let num_tokens = state.num_tokens_generated();
+        // Join the decoder thread so every generated token is decoded and emitted before we
+        // return; otherwise the caller's `handle.join()` races the decoder and the final
+        // in-flight token is dropped.
+        let num_tokens = state.finish();
 
         Ok(GenerationOutput {
             tokens: num_tokens,
@@ -147,7 +150,10 @@ mod tests {
             .unwrap();
 
         let result = handle.join();
-        let expected = "[187][114][51][146][146][250][112][224][192][99][132][0][0][180][192][99][19][114][19][174][0][180][192][131][132][19][99][114][131][132][249][146][82][28][226][226][148][84][19][192][83][99][19][249][19][251][222][19][192][180][192][180][192][0][180][192][146][20][0][180][192][180][20]";
+        // The previous expected value was one token short ([...][180][20]): the final streamed
+        // token was dropped by the now-fixed unjoined decoder-thread race. This is the complete
+        // 64-token (sample_len) deterministic output.
+        let expected = "[187][114][51][146][146][250][112][224][192][99][132][0][0][180][192][99][19][114][19][174][0][180][192][131][132][19][99][114][131][132][249][146][82][28][226][226][148][84][19][192][83][99][19][249][19][251][222][19][192][180][192][180][192][0][180][192][146][20][0][180][192][180][20][0]";
 
         assert_eq!(result, expected);
     }


### PR DESCRIPTION
`Llama::generate` could drop the last streamed token.

`GenerationContext` spawns a background thread that detokenizes generated tokens and streams them to the job emitter, but its `JoinHandle` was discarded. When `generate` returned, the caller's `handle.join()` raced that thread: if the listener observed `Finished` before the thread emitted the final token, that token was lost.

It's a genuine race that simply lands on the truncated side reliably enough to usually pass. `test_llama3_2_3b_test` made it concrete — with `sample_len = 64` the loop produces 64 tokens, but the expected string had only 63: it had been recorded from the truncated output.

## Fix

Store the decoder thread's `JoinHandle` and join it (via `GenerationContext::finish`) before `generate` returns, so every generated token is emitted before the caller observes completion. The expected output in `test_llama3_2_3b_test` is corrected to the full 64-token result.
